### PR TITLE
implement basic handling of inline formatting; emphasis command

### DIFF
--- a/esc2html.php
+++ b/esc2html.php
@@ -83,15 +83,16 @@ function wrapBlock($tag, $closeTag, array $content, $indent = true)
     return $ret;
 }
 
-function span(InlineFormatting $formatting, $text) {
+function span(InlineFormatting $formatting, $text)
+{
     $classes = [];
 
-    if($formatting -> bold) {
+    if ($formatting -> bold) {
         $classes[] = "esc-emphasis";
     }
     
     // Output span with any non-default classes
-    if(count($classes) == 0) {
+    if (count($classes) == 0) {
         return $text;
     }
     return "<span class=\"". implode($classes, " ") . "\">" . $text . "</span>";

--- a/esc2html.php
+++ b/esc2html.php
@@ -5,6 +5,7 @@
 require_once __DIR__ . '/vendor/autoload.php';
 
 use ReceiptPrintHq\EscposTools\Parser\Parser;
+use ReceiptPrintHq\EscposTools\Parser\Context\InlineFormatting;
 
 // Usage
 if (!isset($argv[1])) {
@@ -20,17 +21,25 @@ $parser -> addFile($fp);
 
 // Extract text
 $commands = $parser -> getCommands();
+$formatting = InlineFormatting::getDefault();
 $outp = array();
 $lineHtml = "";
 foreach ($commands as $cmd) {
+    if ($cmd -> isAvailableAs('InitializeCmd')) {
+        $formatting = InlineFormatting::getDefault();
+    }
+    if ($cmd -> isAvailableAs('InlineFormattingCmd')) {
+        $cmd -> applyToInlineFormatting($formatting);
+    }
     if ($cmd -> isAvailableAs('TextContainer')) {
         // Add text to line
-        $lineHtml .= htmlentities($cmd -> getText());
+        $spanContentHtml = htmlentities($cmd -> getText());
+        $lineHtml .= span($formatting, $spanContentHtml);
     }
     if ($cmd -> isAvailableAs('LineBreak')) {
         // Write fresh block element out to HTML
         if ($lineHtml === "") {
-            $lineHtml = "&nbsp;";
+            $lineHtml = span($formatting, "&nbsp;");
         }
         $outp[] = wrapInline("<div class=\"esc-line\">", "</div>", $lineHtml);
         $lineHtml = "";
@@ -49,8 +58,6 @@ $metaInfo = array_merge(
         "</style>"
     )
 );
-
-
 
 // Final document assembly
 $receipt = wrapBlock("<div class=\"esc-receipt\">", "</div>", $outp);
@@ -74,4 +81,18 @@ function wrapBlock($tag, $closeTag, array $content, $indent = true)
     }
     $ret[] = $closeTag;
     return $ret;
+}
+
+function span(InlineFormatting $formatting, $text) {
+    $classes = [];
+
+    if($formatting -> bold) {
+        $classes[] = "esc-emphasis";
+    }
+    
+    // Output span with any non-default classes
+    if(count($classes) == 0) {
+        return $text;
+    }
+    return "<span class=\"". implode($classes, " ") . "\">" . $text . "</span>";
 }

--- a/src/Parser/Command/Command.php
+++ b/src/Parser/Command/Command.php
@@ -20,7 +20,7 @@ abstract class Command
     public function isAvailableAs($interface)
     {
         $className = get_called_class();
-        if($className == "ReceiptPrintHq\\EscposTools\\Parser\\Command\\$interface") {
+        if ($className == "ReceiptPrintHq\\EscposTools\\Parser\\Command\\$interface") {
             return true;
         }
         $impl = class_implements($this);

--- a/src/Parser/Command/Command.php
+++ b/src/Parser/Command/Command.php
@@ -19,6 +19,10 @@ abstract class Command
 
     public function isAvailableAs($interface)
     {
+        $className = get_called_class();
+        if($className == "ReceiptPrintHq\\EscposTools\\Parser\\Command\\$interface") {
+            return true;
+        }
         $impl = class_implements($this);
         return isset($impl["ReceiptPrintHq\\EscposTools\\Parser\\Command\\$interface"]);
     }

--- a/src/Parser/Command/CommandOneArg.php
+++ b/src/Parser/Command/CommandOneArg.php
@@ -17,7 +17,8 @@ class CommandOneArg extends EscposCommand
         }
     }
     
-    protected function getArg() {
+    protected function getArg()
+    {
         return $this -> arg;
     }
 }

--- a/src/Parser/Command/CommandOneArg.php
+++ b/src/Parser/Command/CommandOneArg.php
@@ -16,4 +16,8 @@ class CommandOneArg extends EscposCommand
             return false;
         }
     }
+    
+    protected function getArg() {
+        return $this -> arg;
+    }
 }

--- a/src/Parser/Command/EnableEmphasisCmd.php
+++ b/src/Parser/Command/EnableEmphasisCmd.php
@@ -2,8 +2,12 @@
 namespace ReceiptPrintHq\EscposTools\Parser\Command;
 
 use ReceiptPrintHq\EscposTools\Parser\Command\CommandOneArg;
+use ReceiptPrintHq\EscposTools\Parser\Command\InlineFormattingCmd;
+use ReceiptPrintHq\EscposTools\Parser\Context\InlineFormatting;
 
-class EnableEmphasisCmd extends CommandOneArg
+class EnableEmphasisCmd extends CommandOneArg implements InlineFormattingCmd
 {
-
+    function applyToInlineFormatting(InlineFormatting $formatting) {
+        $formatting -> setBold($this -> getArg() == 1);
+    }
 }

--- a/src/Parser/Command/EnableEmphasisCmd.php
+++ b/src/Parser/Command/EnableEmphasisCmd.php
@@ -7,7 +7,8 @@ use ReceiptPrintHq\EscposTools\Parser\Context\InlineFormatting;
 
 class EnableEmphasisCmd extends CommandOneArg implements InlineFormattingCmd
 {
-    function applyToInlineFormatting(InlineFormatting $formatting) {
+    public function applyToInlineFormatting(InlineFormatting $formatting)
+    {
         $formatting -> setBold($this -> getArg() == 1);
     }
 }

--- a/src/Parser/Command/InlineFormattingCmd.php
+++ b/src/Parser/Command/InlineFormattingCmd.php
@@ -1,7 +1,9 @@
 <?php
 namespace ReceiptPrintHq\EscposTools\Parser\Command;
+
 use ReceiptPrintHq\EscposTools\Parser\Context\InlineFormatting;
 
-interface InlineFormattingCmd {
-    function applyToInlineFormatting(InlineFormatting $formatting);
+interface InlineFormattingCmd
+{
+    public function applyToInlineFormatting(InlineFormatting $formatting);
 }

--- a/src/Parser/Command/InlineFormattingCmd.php
+++ b/src/Parser/Command/InlineFormattingCmd.php
@@ -1,0 +1,7 @@
+<?php
+namespace ReceiptPrintHq\EscposTools\Parser\Command;
+use ReceiptPrintHq\EscposTools\Parser\Context\InlineFormatting;
+
+interface InlineFormattingCmd {
+    function applyToInlineFormatting(InlineFormatting $formatting);
+}

--- a/src/Parser/Context/InlineFormatting.php
+++ b/src/Parser/Context/InlineFormatting.php
@@ -1,18 +1,21 @@
 <?php
 namespace ReceiptPrintHq\EscposTools\Parser\Context;
 
-class InlineFormatting {
+class InlineFormatting
+{
     public $bold = false;
     
-    public function __construct() {
-
+    public function __construct()
+    {
     }
 
-    function setBold($bold) {
+    public function setBold($bold)
+    {
         $this -> bold = $bold;
     }
 
-    public static function getDefault() {
+    public static function getDefault()
+    {
         return new InlineFormatting();
     }
 }

--- a/src/Parser/Context/InlineFormatting.php
+++ b/src/Parser/Context/InlineFormatting.php
@@ -1,0 +1,18 @@
+<?php
+namespace ReceiptPrintHq\EscposTools\Parser\Context;
+
+class InlineFormatting {
+    public $bold = false;
+    
+    public function __construct() {
+
+    }
+
+    function setBold($bold) {
+        $this -> bold = $bold;
+    }
+
+    public static function getDefault() {
+        return new InlineFormatting();
+    }
+}

--- a/src/resources/esc2html.css
+++ b/src/resources/esc2html.css
@@ -9,3 +9,7 @@
 .esc-line {
   white-space: pre;
 }
+
+.esc-emphasis {
+	font-weight: bold;
+}

--- a/src/resources/esc2html.css
+++ b/src/resources/esc2html.css
@@ -11,5 +11,5 @@
 }
 
 .esc-emphasis {
-	font-weight: bold;
+  font-weight: bold;
 }


### PR DESCRIPTION
This pull request addresses emphasis in HTML output (#9) with a basic system for inline formatting - `<span>` in html.

Only the impact of `ESC E` (`EnableEmphasisCmd`) and `ESC @` (`InitializeCmd`) are applied here, other commands probably exist which will also affect this formatting.

![screenshot from 2017-05-20 23-41-48](https://cloud.githubusercontent.com/assets/2080552/26276247/ceb2aed4-3db6-11e7-92d6-0a8bf472fd82.png)
