### PR TITLE
Initial implementation of double-with and double-heigh text in html.

### DIFF
--- a/src/Parser/Command/Printout.php
+++ b/src/Parser/Command/Printout.php
@@ -66,7 +66,7 @@ class Printout extends Command
 
                 ),
                 'L' => 'GraphicsDataCmd',
-                'k' => 'Code2dDataCmd'
+                'k' => 'Code2DDataCmd'
             ),
             'h' => 'SetBarcodeHeightCmd',
             'H' => 'SelectHriPrintPosCmd',

--- a/src/Parser/Command/SelectCharacterSizeCmd.php
+++ b/src/Parser/Command/SelectCharacterSizeCmd.php
@@ -2,8 +2,19 @@
 namespace ReceiptPrintHq\EscposTools\Parser\Command;
 
 use ReceiptPrintHq\EscposTools\Parser\Command\CommandOneArg;
+use ReceiptPrintHq\EscposTools\Parser\Command\InlineFormattingCmd;
+use ReceiptPrintHq\EscposTools\Parser\Context\InlineFormatting;
 
-class SelectCharacterSizeCmd extends CommandOneArg
+class SelectCharacterSizeCmd extends CommandOneArg implements InlineFormattingCmd
 {
-
+    public function applyToInlineFormatting(InlineFormatting $formatting)
+    {
+        $arg = $this -> getArg();
+        // TODO Add height multiples from this command
+        $formatting -> setWidthMultiple(2);
+        $width = intdiv($arg, 16) + 1;
+        $height = ($arg % 16) + 1;
+        $formatting -> setWidthMultiple($width);
+        $formatting -> setHeightMultiple($height);
+    }
 }

--- a/src/Parser/Command/SelectFontCmd.php
+++ b/src/Parser/Command/SelectFontCmd.php
@@ -1,7 +1,7 @@
 <?php
-namespace ReceiptPrintHq\EscposTools;
+namespace ReceiptPrintHq\EscposTools\Parser\Command;
 
-use ReceiptPrintHq\EscposTools\CommandOneArg;
+use ReceiptPrintHq\EscposTools\Parser\Command\CommandOneArg;
 
 class SelectFontCmd extends CommandOneArg
 {

--- a/src/Parser/Command/SelectPrintModeCmd.php
+++ b/src/Parser/Command/SelectPrintModeCmd.php
@@ -2,8 +2,18 @@
 namespace ReceiptPrintHq\EscposTools\Parser\Command;
 
 use ReceiptPrintHq\EscposTools\Parser\Command\CommandOneArg;
+use ReceiptPrintHq\EscposTools\Parser\Command\InlineFormattingCmd;
+use ReceiptPrintHq\EscposTools\Parser\Context\InlineFormatting;
 
-class SelectPrintModeCmd extends CommandOneArg
+class SelectPrintModeCmd extends CommandOneArg implements InlineFormattingCmd
 {
-
+    public function applyToInlineFormatting(InlineFormatting $formatting)
+    {
+        $arg = $this -> getArg();
+        // TODO Add font A/B selection from this command (1)
+        $formatting -> setBold($arg & 8);
+        $formatting -> setHeightMultiple($arg & 16 ? 2 : 1);
+        $formatting -> setWidthMultiple($arg & 32 ? 2 : 1);
+        // TODO Add underline text option from this command (128)
+    }
 }

--- a/src/Parser/Context/InlineFormatting.php
+++ b/src/Parser/Context/InlineFormatting.php
@@ -5,6 +5,9 @@ class InlineFormatting
 {
     public $bold = false;
     
+    public $widthMultiple = 1;
+    public $heightMultiple = 1;
+    
     public function __construct()
     {
     }
@@ -12,6 +15,16 @@ class InlineFormatting
     public function setBold($bold)
     {
         $this -> bold = $bold;
+    }
+    
+    public function setWidthMultiple($width)
+    {
+        $this -> widthMultiple = $width;
+    }
+    
+    public function setHeightMultiple($height)
+    {
+        $this -> heightMultiple = $height;
     }
 
     public static function getDefault()

--- a/src/resources/esc2html.css
+++ b/src/resources/esc2html.css
@@ -13,3 +13,47 @@
 .esc-emphasis {
   font-weight: bold;
 }
+
+.esc-justify-center .esc-text-scaled {
+    transform-origin: 50% 0;
+}
+
+.esc-justify-right .esc-text-scaled {
+    transform-origin: 100% 0;
+}
+
+.esc-justify-center {
+    text-align: center;
+}
+
+.esc-justify-right {
+    text-align: right;
+}
+
+.esc-text-scaled {
+   display: inline-block;
+   transform-origin: 0 0;
+}
+
+span {
+    display: inline-block;
+}
+
+/*
+TODO
+- Generate height/width mixes up to 8x8
+- Figure out how do display multiple height/widths inline correctly
+*/
+.esc-width-2 {
+    transform: scale(2, 1);
+}
+
+.esc-height-2 {
+    transform: scale(1, 2);
+    margin-bottom: 1em;
+}
+
+.esc-width-2-height-2 {
+    transform: scale(2, 2);
+    margin-bottom: 1em;
+}


### PR DESCRIPTION
This pull request implements double-height and double-width text at a line-level. This is triggered by `SelectPrintModeCmd` or `SelectCharacterSizeCmd`. 1x1, 1x2, 2x1 and 2x2 are all supported, with higher multiples capped for some compatibility (eg attempting 4x width will cause 2x width to be used).

Some unrelated bug fixes are also included-

- 2D data code parsing caused a 'class not found' due to a typo
- Emphasis was not applied to `SelectPrintModeCmd`.

Switching the values mid-line does work, but the character alignment (width and height) is quite buggy.

- Multiple heights should go to baseline
- Multiple widths should not overlap

This will require a lot of re-work to display perfectly, and is not as important as some other missing features, so I'm submitting this as-is.

Example from #8-

![screenshot from 2017-05-21 12-51-36](https://cloud.githubusercontent.com/assets/2080552/26280777/5d8caa66-3e24-11e7-840d-ba0a17f4eea0.png)

Larger example showing heights for #12,  outstanding rendering issues-

![screenshot from 2017-05-21 12-57-19](https://cloud.githubusercontent.com/assets/2080552/26280811/0ae5777e-3e25-11e7-8fdf-f6ca382c00df.png)

Reference-
- #8
- #12 