### PR TITLE
Text alignment

### DIFF
--- a/esc2html.php
+++ b/esc2html.php
@@ -42,8 +42,16 @@ foreach ($commands as $cmd) {
         if ($lineHtml === "") {
             $lineHtml = span($formatting);
         }
-        // TODO apply block-level formatting here, such as text justification
-        $outp[] = wrapInline("<div class=\"esc-line\">", "</div>", $lineHtml);
+        // Block-level formatting such as text justification
+        $classes = ["esc-line"];
+        if ($formatting -> justification === InlineFormatting::JUSTIFY_CENTER) {
+            $classes[] = "esc-justify-center";
+        } else if ($formatting -> justification === InlineFormatting::JUSTIFY_RIGHT) {
+            $classes[] = "esc-justify-right";
+        }
+
+        $classesStr = implode($classes, " ");
+        $outp[] = wrapInline("<div class=\"$classesStr\">", "</div>", $lineHtml);
         $lineHtml = "";
     }
 }
@@ -118,8 +126,6 @@ function span(InlineFormatting $formatting, $spanContentText = false)
         $spanContentHtml = htmlentities($spanContentText);
     }
 
-    //str_replace(" ", "&nbsp;", htmlentities());
-    
     // Output span with any non-default classes
     if (count($classes) == 0) {
         return $spanContentHtml;

--- a/src/Parser/Command/SelectJustificationCmd.php
+++ b/src/Parser/Command/SelectJustificationCmd.php
@@ -2,8 +2,20 @@
 namespace ReceiptPrintHq\EscposTools\Parser\Command;
 
 use ReceiptPrintHq\EscposTools\Parser\Command\CommandOneArg;
+use ReceiptPrintHq\EscposTools\Parser\Command\InlineFormattingCmd;
+use ReceiptPrintHq\EscposTools\Parser\Context\InlineFormatting;
 
-class SelectJustificationCmd extends CommandOneArg
+class SelectJustificationCmd extends CommandOneArg implements InlineFormattingCmd
 {
-
+    public function applyToInlineFormatting(InlineFormatting $formatting)
+    {
+        $arg = $this -> getArg();
+        if ($arg === 0 || $arg === 48) {
+            $formatting -> setJustification(InlineFormatting::JUSTIFY_LEFT);
+        } else if ($arg === 1 || $arg === 49) {
+            $formatting -> setJustification(InlineFormatting::JUSTIFY_CENTER);
+        } else if ($arg === 2 || $arg === 50) {
+            $formatting -> setJustification(InlineFormatting::JUSTIFY_RIGHT);
+        }
+    }
 }

--- a/src/Parser/Context/InlineFormatting.php
+++ b/src/Parser/Context/InlineFormatting.php
@@ -1,13 +1,21 @@
 <?php
 namespace ReceiptPrintHq\EscposTools\Parser\Context;
 
+use Mike42\Escpos\Printer;
+
 class InlineFormatting
 {
+    const JUSTIFY_LEFT = 0;
+    const JUSTIFY_CENTER = 1;
+    const JUSTIFY_RIGHT = 2;
+    
     public $bold = false;
     
     public $widthMultiple = 1;
     public $heightMultiple = 1;
-    
+
+    public $justification = InlineFormatting::JUSTIFY_LEFT;
+
     public function __construct()
     {
     }
@@ -25,6 +33,11 @@ class InlineFormatting
     public function setHeightMultiple($height)
     {
         $this -> heightMultiple = $height;
+    }
+
+    public function setJustification($justification)
+    {
+        $this -> justification = $justification;
     }
 
     public static function getDefault()


### PR DESCRIPTION
This pull request maps the ESC/POS `SelectJustificationCmd` to text alignment, allowing the included example's alignment to be shown correctly.

This is applied to each line (block-level).

![screenshot from 2017-05-21 21-01-33](https://cloud.githubusercontent.com/assets/2080552/26283284/b3c6ebe6-3e68-11e7-999c-5694e19a553a.png)

Reference:

- #11