### PR TITLE
Image spacing

### DIFF
--- a/esc2html.php
+++ b/esc2html.php
@@ -59,7 +59,7 @@ foreach ($commands as $cmd) {
             $imgSrc = "data:image/png;base64," . base64_encode($bufferedImg -> asPng());
             $imgWidth = $bufferedImg -> getWidth() / 2; // scaling, images are quite high res and dwarf the text
             $bufferedImg = null;
-            $lineHtml .= "<img src=\"$imgSrc\" alt=\"$imgAlt\" width=\"${imgWidth}px\" />";
+            $lineHtml .= "<img class=\"esc-bitimage\" src=\"$imgSrc\" alt=\"$imgAlt\" width=\"${imgWidth}px\" />";
             // Append and flush buffer
             $classes = getBlockClasses($formatting);
             $classesStr = implode($classes, " ");

--- a/src/resources/esc2html.css
+++ b/src/resources/esc2html.css
@@ -36,8 +36,8 @@
 }
 
 .esc-justify-center .esc-bitimage {
-	margin-left: auto;
-	margin-right: auto;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .esc-justify-right .esc-bitimage {
@@ -68,5 +68,5 @@ TODO
 }
 
 .esc-bitimage {
-	display: block;
+    display: block;
 }

--- a/src/resources/esc2html.css
+++ b/src/resources/esc2html.css
@@ -57,3 +57,7 @@ TODO
     transform: scale(2, 2);
     margin-bottom: 1em;
 }
+
+.esc-bitimage {
+	display: block;
+}

--- a/src/resources/esc2html.css
+++ b/src/resources/esc2html.css
@@ -35,6 +35,15 @@
    transform-origin: 0 0;
 }
 
+.esc-justify-center .esc-bitimage {
+	margin-left: auto;
+	margin-right: auto;
+}
+
+.esc-justify-right .esc-bitimage {
+    margin-left: auto;
+}
+
 span {
     display: inline-block;
 }


### PR DESCRIPTION
This pull request adjusts image output to remove spacing adjacent graphics.

Note: This particular workaround will _not work_ for column format bit images (displayed inline), so expect this particular issue to re-appear once more commands are implemented.