### PR TITLE
Documentation formatting fix

### DIFF
--- a/doc/esc2html.md
+++ b/doc/esc2html.md
@@ -20,7 +20,7 @@ php esc2html FILE
 
 ## Example
 
-````
+```
 $ php esc2html.php receipt-with-logo.bin > receipt-with-logo.html
 ```
 

--- a/doc/esc2text.md
+++ b/doc/esc2text.md
@@ -22,7 +22,7 @@ php esc2text.php FILE [ -v ]
 
 ## Example
 
-````
+```
 $ php esc2text.php receipt-with-logo.bin
 ExampleMart Ltd.
 Shop No. 42.
@@ -42,7 +42,7 @@ Thank you for shopping at ExampleMart
 For trading hours, please visit example.com
 
 Monday 6th of April 2015 02:56:25 PM
-````
+```
 
 The same binary data, when sent to a printer, renders as below:
 

--- a/doc/escimages.md
+++ b/doc/escimages.md
@@ -19,7 +19,7 @@ php escimages.php FILE
 
 ## Example
 
-````
+```
 $ php esc2text.php receipt-with-logo.bin
 ```
 


### PR DESCRIPTION
This pull request corrects some stray backticks in the docs, which were not rendering as expected on GitHub (!).
