### PR TITLE
PHP53 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# OSX
+.DS_Store
+
 # Eclipse files
 .settings/*
 .project

--- a/esc2html.php
+++ b/esc2html.php
@@ -119,7 +119,7 @@ function span(InlineFormatting $formatting, $spanContentText = false)
     
    
     // Determine formatting classes to use
-    $classes = [];
+    $classes = array();
 
     if ($formatting -> bold) {
         $classes[] = "esc-emphasis";

--- a/src/Parser/Command/Printout.php
+++ b/src/Parser/Command/Printout.php
@@ -109,7 +109,7 @@ class Printout extends Command
     public function reset()
     {
         $this -> search = null;
-        $this -> searchStack = [];
+        $this -> searchStack = array();
     }
 
     public function addChar($char)
@@ -174,7 +174,7 @@ class Printout extends Command
             DLE => "DLE",
             CAN => "CAN"
         );
-        $cmdStack = [];
+        $cmdStack = array();
         foreach ($searchStack as $s) {
             if (isset($nonPrintableMap[$s])) {
                 $cmdStack[] = $nonPrintableMap[$s];


### PR DESCRIPTION
Updated array shorthand [] to array() to support PHP 5.3, ignoring .DS_Store.