### PR TITLE
Allow parser to recognise and step through commands 'GS B' and 'ESC {'

### DIFF
--- a/src/Parser/Command/EnableBlackWhiteInvertCmd.php
+++ b/src/Parser/Command/EnableBlackWhiteInvertCmd.php
@@ -1,0 +1,9 @@
+<?php
+namespace ReceiptPrintHq\EscposTools\Parser\Command;
+
+use ReceiptPrintHq\EscposTools\Parser\Command\CommandOneArg;
+
+class EnableBlackWhiteInvertCmd extends CommandOneArg
+{
+
+}

--- a/src/Parser/Command/EnableUpsideDownPrintModeCmd.php
+++ b/src/Parser/Command/EnableUpsideDownPrintModeCmd.php
@@ -1,0 +1,9 @@
+<?php
+namespace ReceiptPrintHq\EscposTools\Parser\Command;
+
+use ReceiptPrintHq\EscposTools\Parser\Command\CommandOneArg;
+
+class EnableUpsideDownPrintModeCmd extends CommandOneArg
+{
+
+}

--- a/src/Parser/Command/Printout.php
+++ b/src/Parser/Command/Printout.php
@@ -28,6 +28,7 @@ class Printout extends Command
             '@' => 'InitializeCmd',
             '*' => 'SelectBitImageModeCmd',
             '!' => 'SelectPrintModeCmd',
+            '{' => 'EnableUpsideDownPrintModeCmd',
             '=' => 'SelectPeripheralDeviceCmd',
             'c' => array(
                 '0' => 'UnknownCommandOneArg',
@@ -57,6 +58,7 @@ class Printout extends Command
             '!' => 'SelectCharacterSizeCmd',
             'V' => 'FeedAndCutCmd',
             'b' => 'EnableSmoothingCmd',
+            'B' => 'EnableBlackWhiteInvertCmd',
             '(' => array(
                 'C' => array(
 


### PR DESCRIPTION
Add commands to parser so that they can be recognised and ignored.

Reference:

- #53 