### PR TITLE
Fix text sizes, fixes to avoid missing text after images

### DIFF
--- a/esc2html.php
+++ b/esc2html.php
@@ -123,16 +123,15 @@ function wrapBlock($tag, $closeTag, array $content, $indent = true)
 function span(InlineFormatting $formatting, $spanContentText = false)
 {
     // Gut some features-
-    if ($formatting -> widthMultiple > 2) {
+    if ($formatting -> widthMultiple > 8) {
         // Widths > 2 are not implemented. Cap the width at 2 to avoid formatting issues.
-        $formatting -> widthMultiple = 2;
+        $formatting -> widthMultiple = 8;
     }
-    if ($formatting -> heightMultiple > 2) {
-        // Widths > 2 are not implemented either
-        $formatting -> heightMultiple = 2;
+    if ($formatting -> heightMultiple > 8) {
+        // Widths > 8 are not implemented either
+        $formatting -> heightMultiple = 8;
     }
-    
-   
+
     // Determine formatting classes to use
     $classes = array();
 

--- a/src/Parser/Command/FeedAndCutCmd.php
+++ b/src/Parser/Command/FeedAndCutCmd.php
@@ -3,7 +3,7 @@ namespace ReceiptPrintHq\EscposTools\Parser\Command;
 
 use ReceiptPrintHq\EscposTools\Parser\Command\Command;
 
-class FeedAndCutCmd extends Command
+class FeedAndCutCmd extends Command implements LineBreak
 {
     private $arg1 = null;
     private $arg2 = null;

--- a/src/resources/esc2html.css
+++ b/src/resources/esc2html.css
@@ -3,6 +3,7 @@
   font-family: monospace;
   margin: 1em;
   padding: 1em;
+  min-width: 28em;
   display: inline-block;
 }
 
@@ -78,14 +79,308 @@ TODO
     transform: scale(2, 1);
 }
 
+.esc-width-3 {
+    transform: scale(3, 1);
+}
+
+.esc-width-4 {
+    transform: scale(4, 1);
+}
+
+.esc-width-5 {
+    transform: scale(5, 1);
+}
+
+.esc-width-6 {
+    transform: scale(6, 1);
+}
+
+.esc-width-7 {
+    transform: scale(7, 1);
+}
+
+.esc-width-8 {
+    transform: scale(8, 1);
+}
+
 .esc-height-2 {
     transform: scale(1, 2);
     margin-bottom: 1em;
 }
 
+.esc-height-3 {
+    transform: scale(1, 3);
+    margin-bottom: 2em;
+}
+
+.esc-height-3 {
+    transform: scale(1, 4);
+    margin-bottom: 3em;
+}
+
+.esc-height-4 {
+    transform: scale(1, 5);
+    margin-bottom: 4em;
+}
+
+.esc-height-6 {
+    transform: scale(1, 6);
+    margin-bottom: 5em;
+}
+
+.esc-height-7 {
+    transform: scale(1, 7);
+    margin-bottom: 6em;
+}
+
+.esc-height-8 {
+    transform: scale(1, 8);
+    margin-bottom: 7em;
+}
+
 .esc-width-2-height-2 {
     transform: scale(2, 2);
     margin-bottom: 1em;
+}
+
+.esc-width-2-height-3 {
+    transform: scale(2, 3);
+    margin-bottom: 2em;
+}
+
+.esc-width-2-height-3 {
+    transform: scale(2, 4);
+    margin-bottom: 3em;
+}
+
+.esc-width-2-height-4 {
+    transform: scale(2, 5);
+    margin-bottom: 4em;
+}
+
+.esc-width-2-height-6 {
+    transform: scale(2, 6);
+    margin-bottom: 5em;
+}
+
+.esc-width-2-height-7 {
+    transform: scale(2, 7);
+    margin-bottom: 6em;
+}
+
+.esc-width-2-height-8 {
+    transform: scale(2, 8);
+    margin-bottom: 7em;
+}
+
+.esc-width-3-height-2 {
+    transform: scale(3, 2);
+    margin-bottom: 1em;
+}
+
+.esc-width-3-height-3 {
+    transform: scale(3, 3);
+    margin-bottom: 2em;
+}
+
+.esc-width-3-height-3 {
+    transform: scale(3, 4);
+    margin-bottom: 3em;
+}
+
+.esc-width-3-height-4 {
+    transform: scale(3, 5);
+    margin-bottom: 4em;
+}
+
+.esc-width-3-height-6 {
+    transform: scale(3, 6);
+    margin-bottom: 5em;
+}
+
+.esc-width-3-height-7 {
+    transform: scale(3, 7);
+    margin-bottom: 6em;
+}
+
+.esc-width-3-height-8 {
+    transform: scale(3, 8);
+    margin-bottom: 7em;
+}
+
+.esc-width-4-height-2 {
+    transform: scale(4, 2);
+    margin-bottom: 1em;
+}
+
+.esc-width-4-height-3 {
+    transform: scale(4, 3);
+    margin-bottom: 2em;
+}
+
+.esc-width-4-height-3 {
+    transform: scale(4, 4);
+    margin-bottom: 3em;
+}
+
+.esc-width-4-height-4 {
+    transform: scale(4, 5);
+    margin-bottom: 4em;
+}
+
+.esc-width-4-height-6 {
+    transform: scale(4, 6);
+    margin-bottom: 5em;
+}
+
+.esc-width-4-height-7 {
+    transform: scale(4, 7);
+    margin-bottom: 6em;
+}
+
+.esc-width-4-height-8 {
+    transform: scale(4, 8);
+    margin-bottom: 7em;
+}
+
+.esc-width-5-height-2 {
+    transform: scale(5, 2);
+    margin-bottom: 1em;
+}
+
+.esc-width-5-height-3 {
+    transform: scale(5, 3);
+    margin-bottom: 2em;
+}
+
+.esc-width-5-height-3 {
+    transform: scale(5, 4);
+    margin-bottom: 3em;
+}
+
+.esc-width-5-height-4 {
+    transform: scale(5, 5);
+    margin-bottom: 4em;
+}
+
+.esc-width-5-height-6 {
+    transform: scale(5, 6);
+    margin-bottom: 5em;
+}
+
+.esc-width-5-height-7 {
+    transform: scale(5, 7);
+    margin-bottom: 6em;
+}
+
+.esc-width-5-height-8 {
+    transform: scale(5, 8);
+    margin-bottom: 7em;
+}
+
+.esc-width-6-height-2 {
+    transform: scale(6, 2);
+    margin-bottom: 1em;
+}
+
+.esc-width-6-height-3 {
+    transform: scale(6, 3);
+    margin-bottom: 2em;
+}
+
+.esc-width-6-height-3 {
+    transform: scale(6, 4);
+    margin-bottom: 3em;
+}
+
+.esc-width-6-height-4 {
+    transform: scale(6, 5);
+    margin-bottom: 4em;
+}
+
+.esc-width-6-height-6 {
+    transform: scale(6, 6);
+    margin-bottom: 5em;
+}
+
+.esc-width-6-height-7 {
+    transform: scale(6, 7);
+    margin-bottom: 6em;
+}
+
+.esc-width-6-height-8 {
+    transform: scale(6, 8);
+    margin-bottom: 7em;
+}
+
+.esc-width-7-height-2 {
+    transform: scale(7, 2);
+    margin-bottom: 1em;
+}
+
+.esc-width-7-height-3 {
+    transform: scale(7, 3);
+    margin-bottom: 2em;
+}
+
+.esc-width-7-height-3 {
+    transform: scale(7, 4);
+    margin-bottom: 3em;
+}
+
+.esc-width-7-height-4 {
+    transform: scale(7, 5);
+    margin-bottom: 4em;
+}
+
+.esc-width-7-height-6 {
+    transform: scale(7, 6);
+    margin-bottom: 5em;
+}
+
+.esc-width-7-height-7 {
+    transform: scale(7, 7);
+    margin-bottom: 6em;
+}
+
+.esc-width-7-height-8 {
+    transform: scale(7, 8);
+    margin-bottom: 7em;
+}
+
+.esc-width-8-height-2 {
+    transform: scale(8, 2);
+    margin-bottom: 1em;
+}
+
+.esc-width-8-height-3 {
+    transform: scale(8, 3);
+    margin-bottom: 2em;
+}
+
+.esc-width-8-height-3 {
+    transform: scale(8, 4);
+    margin-bottom: 3em;
+}
+
+.esc-width-8-height-4 {
+    transform: scale(8, 5);
+    margin-bottom: 4em;
+}
+
+.esc-width-8-height-6 {
+    transform: scale(8, 6);
+    margin-bottom: 5em;
+}
+
+.esc-width-8-height-7 {
+    transform: scale(8, 7);
+    margin-bottom: 6em;
+}
+
+.esc-width-8-height-8 {
+    transform: scale(8, 8);
+    margin-bottom: 7em;
 }
 
 .esc-bitimage {

--- a/src/resources/esc2html.css
+++ b/src/resources/esc2html.css
@@ -113,12 +113,12 @@ TODO
     margin-bottom: 2em;
 }
 
-.esc-height-3 {
+.esc-height-4 {
     transform: scale(1, 4);
     margin-bottom: 3em;
 }
 
-.esc-height-4 {
+.esc-height-5 {
     transform: scale(1, 5);
     margin-bottom: 4em;
 }
@@ -148,12 +148,12 @@ TODO
     margin-bottom: 2em;
 }
 
-.esc-width-2-height-3 {
+.esc-width-2-height-4 {
     transform: scale(2, 4);
     margin-bottom: 3em;
 }
 
-.esc-width-2-height-4 {
+.esc-width-2-height-5 {
     transform: scale(2, 5);
     margin-bottom: 4em;
 }
@@ -183,12 +183,12 @@ TODO
     margin-bottom: 2em;
 }
 
-.esc-width-3-height-3 {
+.esc-width-3-height-4 {
     transform: scale(3, 4);
     margin-bottom: 3em;
 }
 
-.esc-width-3-height-4 {
+.esc-width-3-height-5 {
     transform: scale(3, 5);
     margin-bottom: 4em;
 }
@@ -218,12 +218,12 @@ TODO
     margin-bottom: 2em;
 }
 
-.esc-width-4-height-3 {
+.esc-width-4-height-4 {
     transform: scale(4, 4);
     margin-bottom: 3em;
 }
 
-.esc-width-4-height-4 {
+.esc-width-4-height-5 {
     transform: scale(4, 5);
     margin-bottom: 4em;
 }
@@ -253,12 +253,12 @@ TODO
     margin-bottom: 2em;
 }
 
-.esc-width-5-height-3 {
+.esc-width-5-height-4 {
     transform: scale(5, 4);
     margin-bottom: 3em;
 }
 
-.esc-width-5-height-4 {
+.esc-width-5-height-5 {
     transform: scale(5, 5);
     margin-bottom: 4em;
 }
@@ -288,12 +288,12 @@ TODO
     margin-bottom: 2em;
 }
 
-.esc-width-6-height-3 {
+.esc-width-6-height-4 {
     transform: scale(6, 4);
     margin-bottom: 3em;
 }
 
-.esc-width-6-height-4 {
+.esc-width-6-height-5 {
     transform: scale(6, 5);
     margin-bottom: 4em;
 }
@@ -323,12 +323,12 @@ TODO
     margin-bottom: 2em;
 }
 
-.esc-width-7-height-3 {
+.esc-width-7-height-4 {
     transform: scale(7, 4);
     margin-bottom: 3em;
 }
 
-.esc-width-7-height-4 {
+.esc-width-7-height-5 {
     transform: scale(7, 5);
     margin-bottom: 4em;
 }
@@ -358,12 +358,12 @@ TODO
     margin-bottom: 2em;
 }
 
-.esc-width-8-height-3 {
+.esc-width-8-height-4 {
     transform: scale(8, 4);
     margin-bottom: 3em;
 }
 
-.esc-width-8-height-4 {
+.esc-width-8-height-5 {
     transform: scale(8, 5);
     margin-bottom: 4em;
 }


### PR DESCRIPTION
Output for `text-size.bin` test file from `escpos-php` shows improvement, though mixing widths on the same line is still problematic:

![image](https://user-images.githubusercontent.com/2080552/53800011-e9638f00-3f8f-11e9-9119-67cd67981aff.png)

The text below this image was previously not being displayed.

![image](https://user-images.githubusercontent.com/2080552/53799654-f7fd7680-3f8e-11e9-943f-25130610a111.png)
