### PR TITLE
Set escpos binary file encoding type in environment variable

### DIFF
--- a/doc/esc2html.md
+++ b/doc/esc2html.md
@@ -1,7 +1,7 @@
 # esc2html
 
 `esc2html` converts an ESC/POS binary file into a HTML document. It is currently capable of rendering some types of
-formatting and images, plus any ASCII text in the input file.
+formatting and images, plus any ASCII text in the input file. Default encoding is [CP437](https://en.wikipedia.org/wiki/Code_page_437) If your ESC/POS binary file different encoding, set **SOURCE_ENCODING** environment variable.
 
 ```
 $ php esc2html.php receipt-with-logo.bin > output.html

--- a/doc/esc2text.md
+++ b/doc/esc2text.md
@@ -2,6 +2,8 @@
 
 `esc2text` extracts text from binary ESC/POS files.
 
+Default encoding is [CP437](https://en.wikipedia.org/wiki/Code_page_437) If your ESC/POS binary file different encoding, set **SOURCE_ENCODING** environment variable.
+
 The plaintext output is UTF-8 encoded, and written to standard output.
 
 It operates by reading all of the commands in the input file, and discarding

--- a/doc/escimages.md
+++ b/doc/escimages.md
@@ -5,6 +5,8 @@
 All non-graphical elements of the receipt are ignored, and a pair of files is
 written (in PBM and PNG format) for each image found in the source file.
 
+Default encoding is [CP437](https://en.wikipedia.org/wiki/Code_page_437) If your ESC/POS binary file different encoding, set **SOURCE_ENCODING** environment variable.
+
 ## Installation
 
 This utility is included with escpos-tools. See the

--- a/src/Parser/Command/TextCmd.php
+++ b/src/Parser/Command/TextCmd.php
@@ -14,7 +14,7 @@ class TextCmd extends Command implements TextContainer
             // Reject ESC/POS control chars.
             return false;
         }
-        $this -> str .= iconv('CP437', 'UTF-8', $char);
+        $this -> str .= iconv(getenv('SOURCE_ENCODING')?: 'CP437', 'UTF-8', $char);
         return true;
     }
 


### PR DESCRIPTION
#61 

Setting the Environment variable "SOURCE_ENCODING" for other than [CP437](https://en.wikipedia.org/wiki/Code_page_437) encoding