### PR TITLE
Add alternate color (red) to the conversion to HTML

### DIFF
--- a/esc2html.php
+++ b/esc2html.php
@@ -49,7 +49,7 @@ foreach ($commands as $cmd) {
         }
         // Block-level formatting such as text justification
         $classes = getBlockClasses($formatting);
-        $classesStr = implode($classes, " ");
+        $classesStr = implode(" ", $classes);
         $outp[] = wrapInline("<div class=\"$classesStr\">", "</div>", $lineHtml);
         $lineHtml = "";
     }
@@ -60,14 +60,14 @@ foreach ($commands as $cmd) {
         } else if ($sub -> isAvailableAs('PrintBufferredDataGraphicsSubCmd') && $bufferedImg !== null) {
             // Append and flush buffer
             $classes = getBlockClasses($formatting);
-            $classesStr = implode($classes, " ");
+            $classesStr = implode(" ", $classes);
             $outp[] = wrapInline("<div class=\"$classesStr\">", "</div>", imgAsDataUrl($bufferedImg));
             $lineHtml = "";
         }
     } else if ($cmd -> isAvailableAs('ImageContainer')) {
         // Append and flush buffer
         $classes = getBlockClasses($formatting);
-        $classesStr = implode($classes, " ");
+        $classesStr = implode(" ", $classes);
         $outp[] = wrapInline("<div class=\"$classesStr\">", "</div>", imgAsDataUrl($cmd));
         $lineHtml = "";
         // Should load into print buffer and print next line break, but we print immediately, so need to skip the next line break.
@@ -169,7 +169,7 @@ function span(InlineFormatting $formatting, $spanContentText = false)
     if (count($classes) == 0) {
         return $spanContentHtml;
     }
-    return "<span class=\"". implode($classes, " ") . "\">" . $spanContentHtml . "</span>";
+    return "<span class=\"". implode(" ", $classes) . "\">" . $spanContentHtml . "</span>";
 }
 
 function getBlockClasses($formatting)

--- a/esc2html.php
+++ b/esc2html.php
@@ -158,6 +158,10 @@ function span(InlineFormatting $formatting, $spanContentText = false)
         $classes[] = "esc" . $widthClass . $heightClass;
     }
 
+    if ($formatting->alternateColor) {
+        $classes[] = 'esc-alternate-color';
+    }
+
     // Provide span content as HTML
     if ($spanContentText === false) {
         $spanContentHtml = "&nbsp;";

--- a/src/Parser/Command/SelectAlternateColorCmd.php
+++ b/src/Parser/Command/SelectAlternateColorCmd.php
@@ -2,8 +2,18 @@
 namespace ReceiptPrintHq\EscposTools\Parser\Command;
 
 use ReceiptPrintHq\EscposTools\Parser\Command\CommandOneArg;
+use ReceiptPrintHq\EscposTools\Parser\Command\InlineFormattingCmd;
+use ReceiptPrintHq\EscposTools\Parser\Context\InlineFormatting;
 
-class SelectAlternateColorCmd extends CommandOneArg
+class SelectAlternateColorCmd extends CommandOneArg implements InlineFormattingCmd
 {
-
+    public function applyToInlineFormatting(InlineFormatting $formatting)
+    {
+        $arg = $this -> getArg();
+        if ($arg === 0 || $arg === 48) {
+            $formatting -> setAlternateColor(false);
+        } elseif ($arg === 1 || $arg === 49) {
+            $formatting -> setAlternateColor(true);
+        }
+    }
 }

--- a/src/Parser/Context/InlineFormatting.php
+++ b/src/Parser/Context/InlineFormatting.php
@@ -21,6 +21,7 @@ class InlineFormatting
     public $invert;
     public $font;
     public $upsideDown;
+    public $alternateColor;
 
     public function __construct()
     {
@@ -67,6 +68,11 @@ class InlineFormatting
         $this -> upsideDown = $upsideDown;
     }
 
+    public function setAlternateColor($alternateColor)
+    {
+        $this -> alternateColor = $alternateColor;
+    }
+
     public static function getDefault()
     {
         return new InlineFormatting();
@@ -82,5 +88,6 @@ class InlineFormatting
         $this -> invert = false;
         $this -> font = 0;
         $this -> upsideDown = false;
+        $this -> alternateColor = false;
     }
 }

--- a/src/resources/esc2html.css
+++ b/src/resources/esc2html.css
@@ -386,3 +386,7 @@ TODO
 .esc-bitimage {
     display: block;
 }
+
+.esc-alternate-color {
+    color: red;
+}


### PR DESCRIPTION
Example file with alternate color [20171026095727437663497.txt](https://github.com/receipt-print-hq/escpos-tools/files/6729737/20171026095727437663497.txt)

Picture of the converted receipt
<img src="https://user-images.githubusercontent.com/26336005/123717674-ec5ea980-d842-11eb-9c66-ebe1c63f20ee.png" width="50%" height="50%">