### PR TITLE
Update to PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"require" : {
-		"squizlabs/php_codesniffer" : "^2.8",
+		"squizlabs/php_codesniffer" : "^3.0",
 		"mike42/escpos-php": "^1.5"
 	},
 	"autoload" : {

--- a/composer.lock
+++ b/composer.lock
@@ -1,24 +1,23 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "hash": "b5630260eb622bbc042c2d420c2abe1e",
-    "content-hash": "ea62982abf2ff4d1f3c1f9246556fbb2",
+    "content-hash": "46a816a57618a5316ff186c7fa1a4834",
     "packages": [
         {
             "name": "mike42/escpos-php",
-            "version": "v1.5.1",
+            "version": "v1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mike42/escpos-php.git",
-                "reference": "11d8ed8950b775c6f120722de10ee2ef6fb90f18"
+                "reference": "995d9a74d4fec9e0b99ddaf308bac4fec05efc40"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mike42/escpos-php/zipball/11d8ed8950b775c6f120722de10ee2ef6fb90f18",
-                "reference": "11d8ed8950b775c6f120722de10ee2ef6fb90f18",
+                "url": "https://api.github.com/repos/mike42/escpos-php/zipball/995d9a74d4fec9e0b99ddaf308bac4fec05efc40",
+                "reference": "995d9a74d4fec9e0b99ddaf308bac4fec05efc40",
                 "shasum": ""
             },
             "require": {
@@ -60,67 +59,44 @@
                 "print",
                 "receipt"
             ],
-            "time": "2017-03-12 12:17:11"
+            "support": {
+                "issues": "https://github.com/mike42/escpos-php/issues",
+                "source": "https://github.com/mike42/escpos-php/tree/master"
+            },
+            "time": "2017-11-05T10:18:27+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.8.1",
+            "version": "3.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d"
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
-                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
+                "bin/phpcs",
+                "bin/phpcbf"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev"
                 }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -133,12 +109,18 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
-                "standards"
+                "standards",
+                "static analysis"
             ],
-            "time": "2017-03-01 22:17:45"
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2023-02-22T23:07:41+00:00"
         }
     ],
     "packages-dev": [],
@@ -148,5 +130,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
 }

--- a/esc2html.php
+++ b/esc2html.php
@@ -49,7 +49,7 @@ foreach ($commands as $cmd) {
         }
         // Block-level formatting such as text justification
         $classes = getBlockClasses($formatting);
-        $classesStr = implode($classes, " ");
+        $classesStr = implode(" ", $classes);
         $outp[] = wrapInline("<div class=\"$classesStr\">", "</div>", $lineHtml);
         $lineHtml = "";
     }
@@ -60,14 +60,14 @@ foreach ($commands as $cmd) {
         } else if ($sub -> isAvailableAs('PrintBufferredDataGraphicsSubCmd') && $bufferedImg !== null) {
             // Append and flush buffer
             $classes = getBlockClasses($formatting);
-            $classesStr = implode($classes, " ");
+            $classesStr = implode(" ", $classes);
             $outp[] = wrapInline("<div class=\"$classesStr\">", "</div>", imgAsDataUrl($bufferedImg));
             $lineHtml = "";
         }
     } else if ($cmd -> isAvailableAs('ImageContainer')) {
         // Append and flush buffer
         $classes = getBlockClasses($formatting);
-        $classesStr = implode($classes, " ");
+        $classesStr = implode(" ", $classes);
         $outp[] = wrapInline("<div class=\"$classesStr\">", "</div>", imgAsDataUrl($cmd));
         $lineHtml = "";
         // Should load into print buffer and print next line break, but we print immediately, so need to skip the next line break.
@@ -101,7 +101,7 @@ function imgAsDataUrl($bufferedImg)
     $imgSrc = "data:image/png;base64," . base64_encode($bufferedImg -> asPng());
     $imgWidth = $bufferedImg -> getWidth() / 2; // scaling, images are quite high res and dwarf the text
     $bufferedImg = null;
-    return "<img class=\"esc-bitimage\" src=\"$imgSrc\" alt=\"$imgAlt\" width=\"${imgWidth}px\" />";
+    return "<img class=\"esc-bitimage\" src=\"$imgSrc\" alt=\"$imgAlt\" width=\"{$imgWidth}px\" />";
 }
 
 function wrapInline($tag, $closeTag, $content)
@@ -169,7 +169,7 @@ function span(InlineFormatting $formatting, $spanContentText = false)
     if (count($classes) == 0) {
         return $spanContentHtml;
     }
-    return "<span class=\"". implode($classes, " ") . "\">" . $spanContentHtml . "</span>";
+    return "<span class=\"". implode(" ", $classes) . "\">" . $spanContentHtml . "</span>";
 }
 
 function getBlockClasses($formatting)

--- a/src/Parser/Command/Printout.php
+++ b/src/Parser/Command/Printout.php
@@ -186,6 +186,6 @@ class Printout extends Command
                 $cmdStack[] = $s;
             }
         }
-        fwrite(STDERR, "WARNING: Unknown command " . implode($cmdStack, ' ') . "\n");
+        fwrite(STDERR, "WARNING: Unknown command " . implode(' ', $cmdStack) . "\n");
     }
 }


### PR DESCRIPTION
When running `esc2html` with PHP v8.2.9 on MacOS I got some warnings and errors:

```
PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /Users/pharkas/code/escpos-tools/esc2html.php on line 104
PHP Fatal error:  Uncaught TypeError: implode(): Argument #1 ($separator) must be of type string, array given in /Users/pharkas/code/escpos-tools/esc2html.php:63
```

It looks like the old `implode(array $array, string $separator): string` API was removed in PHP 8.0.0, but the fix is simple- just swap the arguments. I also fixed the warning about ${var} in strings being deprecated. 

I ran a code style check with `php vendor/bin/phpcs --standard=psr2 src/ -n` but got an error because php_codesniffer was out of date, so I bumped it up to `^3.0`